### PR TITLE
Update key naming schema

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -2,10 +2,7 @@ var AWS = require("aws-sdk");
 var path = require("path");
 var fs = require("fs");
 var _ = require("lodash");
-// var async = require('async');
-// var mimeTypes = require('mime-types');
 var shelljs = require("shelljs");
-// var del = require('del')
 
 function getEnvVariable(name, fallback) {
   let envVar;
@@ -22,12 +19,14 @@ function getEnvVariable(name, fallback) {
 }
 
 const AWS_BUCKET_NAME = "frontier-packagelock";
+let COMMIT_SHA_TRIMMED;
 
 try {
   AWS.config.maxRetries = 10;
   AWS.config.accessKeyId = getEnvVariable("S3_ACCESS_KEY");
   AWS.config.secretAccessKey = getEnvVariable("S3_SECRET_ACCESS_KEY");
   AWS.config.region = getEnvVariable("AWS_DEFAULT_REGION", "us-east-1");
+  COMMIT_SHA_TRIMMED = getEnvVariable("BUILD_GIT_CURRENT_SHA", "unknown-sha").slice(0, 20);
 } catch (error) {
   console.error("Dependency Reporter is not configured for this deploy");
   console.error(error);
@@ -36,18 +35,21 @@ try {
 }
 
 try {
-  const TARGET_ENV = getEnvVariable("TARGET_ENV", "unknown");
+  // const TARGET_ENV = getEnvVariable("TARGET_ENV", "unknown");
   const APP_NAME = getEnvVariable("APP_NAME", "unknown");
   const APP_DIR = process.env.BUILD_DIR || process.cwd();
   // Upload to S3 depending on build env -- if TARGET_ENV is "beta", upload to "dev" bucket. If TARGET_ENV is "build", upload to "prod" bucket.
-  const BUCKET_ENV =
-    TARGET_ENV === "beta" ? "dev" : TARGET_ENV === "build" ? "prod" : "prod"; // Default to "prod" bucket.
+  // For now, we're using all three deployed frapi buckets for testing, so we'll set the bucket_env manually in each set of parameters.
+  // Revisit later once we're out of the testing phase.
+  // const BUCKET_ENV = TARGET_ENV === "beta" ? "dev" : TARGET_ENV === "build" ? "prod" : "prod"; // Default to "prod" bucket.
 
   console.log("Current Working Directory before CD: ", process.cwd());
   console.log("Changing directory to: ", APP_DIR);
 
   shelljs.cd(APP_DIR); // CD into the project directory
   console.log("Current Working Directory after CD: ", process.cwd());
+
+  let packageLockGenerated = false;
 
   if (!fs.existsSync("package-lock.json")) {
     console.log(
@@ -56,31 +58,66 @@ try {
     shelljs.exec("npm install --package-lock-only");
 
     console.log("New package-lock.json file generated.");
+
+    packageLockGenerated = true;
   } else {
     console.log("package-lock.json already exists.");
   }
   console.log(
-    `Uploading package-lock.json file to S3 in ${AWS.config.region} for ${APP_NAME} to ${AWS_BUCKET_NAME}-${BUCKET_ENV}...`
+    `Uploading package-lock.json file to S3 in ${AWS.config.region} for ${APP_NAME} to frapi...`
   );
-  const params = {
-    Bucket: `${AWS_BUCKET_NAME}-${BUCKET_ENV}`,
+
+  const devParams = {
+    Bucket: `${AWS_BUCKET_NAME}-dev`,
+    Key: `${APP_NAME}/${COMMIT_SHA_TRIMMED}-package-lock${packageLockGenerated ? '-generated' : ''}.json`,
+    Body: fs.createReadStream("package-lock.json"),
+  }
+
+  const testParams = {
+    Bucket: `${AWS_BUCKET_NAME}-test`,
+    Key: `${APP_NAME}/${COMMIT_SHA_TRIMMED}-package-lock${packageLockGenerated ? '-generated' : ''}.json`,
+    Body: fs.createReadStream("package-lock.json"),
+  }
+
+  const prodParams = {
+    Bucket: `${AWS_BUCKET_NAME}-prod`,
     Key: `${APP_NAME}/${Date.now()}-package-lock.json`,
     Body: fs.createReadStream("package-lock.json"),
   };
 
   const s3 = new AWS.S3();
 
-  const result = s3.upload(params, (err, data) => {
+  s3.upload(devParams, (err, data) => {
     if (err) {
-      console.error("Error uploading package-lock.json file to S3");
+      console.error("Error uploading dev package-lock.json file to S3");
       console.error(err);
     } else {
-      console.log("Successfully uploaded package-lock.json file to S3");
+      console.log("Successfully uploaded dev package-lock.json file to S3");
+      console.log(data);
+    }
+  });
+
+  s3.upload(testParams, (err, data) => {
+    if (err) {
+      console.error("Error uploading test package-lock.json file to S3");
+      console.error(err);
+    } else {
+      console.log("Successfully uploaded test package-lock.json file to S3");
+      console.log(data);
+    }
+  });
+
+  s3.upload(prodParams, (err, data) => {
+    if (err) {
+      console.error("Error uploading prod package-lock.json file to S3");
+      console.error(err);
+    } else {
+      console.log("Successfully uploaded prod package-lock.json file to S3");
       console.log(data);
     }
   });
 } catch (error) {
-  console.error("Error uploading package-lock.json file to S3");
+  console.error("Error uploading package-lock.json files to S3");
   console.error(error);
   console.error("Exiting upload task without error");
   process.exit(0);


### PR DESCRIPTION
We want to update the packagelock naming schema in S3 to use the SHA hash of the associated build commit such that we can determine at deploy time which lockfile dependencies should be displayed on the Frontier dashboard. While we are testing this system, we will leverage the fact that FRAPI has three buckets currently deployed. We will use the dev bucket to store all of the lockfiles from build time and the test bucket to simulate how the prod bucket will track the current deployed version of an app's dependencies. 

We also append `-generated` to the lockfile names for packages where we need to generate the lockfile within the buildpack. We may be able to leverage this later in the Frontier dashboard to display which apps are currently not using a lockfile to manage their dependencies.