### PR TITLE
Name prod lockfiles by commit SHA so frapi can promote them

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -85,8 +85,8 @@ try {
   // commit SHA, so no prod lockfile was ever promotable.
   const key = `${APP_NAME}/${COMMIT_SHA_TRIMMED}-package-lock${packageLockGenerated ? '-generated' : ''}.json`;
 
-  // Read once into a buffer rather than opening a stream per upload: a read stream can only be
-  // consumed once, so sharing one across the three uploads would silently truncate two of them.
+  // Read once into a buffer so the payload can be reused across multiple uploads. (A single
+  // ReadStream can only be consumed once; reusing it across the three uploads would truncate two.)
   const body = fs.readFileSync("package-lock.json");
 
   const s3 = new AWS.S3();

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -1,7 +1,6 @@
 var AWS = require("aws-sdk");
 var path = require("path");
 var fs = require("fs");
-var _ = require("lodash");
 var shelljs = require("shelljs");
 
 function getEnvVariable(name, fallback) {
@@ -19,6 +18,8 @@ function getEnvVariable(name, fallback) {
 }
 
 const AWS_BUCKET_NAME = "frontier-packagelock";
+const BUCKET_ENVS = ["dev", "test", "prod"];
+const UNKNOWN_SHA = "unknown-sha";
 let COMMIT_SHA_TRIMMED;
 
 try {
@@ -26,7 +27,10 @@ try {
   AWS.config.accessKeyId = getEnvVariable("S3_ACCESS_KEY");
   AWS.config.secretAccessKey = getEnvVariable("S3_SECRET_ACCESS_KEY");
   AWS.config.region = getEnvVariable("AWS_DEFAULT_REGION", "us-east-1");
-  COMMIT_SHA_TRIMMED = getEnvVariable("BUILD_GIT_CURRENT_SHA", "unknown-sha").slice(0, 20);
+  // frapi's PromoteDeployedDependencies finds a build's lockfile by the first 20 characters of
+  // the deploy's commit SHA, so this prefix is a contract with that lambda. Changing the length
+  // or the filename shape below breaks promotion silently.
+  COMMIT_SHA_TRIMMED = getEnvVariable("BUILD_GIT_CURRENT_SHA", UNKNOWN_SHA).slice(0, 20);
 } catch (error) {
   console.error("Dependency Reporter is not configured for this deploy");
   console.error(error);
@@ -43,6 +47,15 @@ try {
   // Revisit later once we're out of the testing phase.
   // const BUCKET_ENV = TARGET_ENV === "beta" ? "dev" : TARGET_ENV === "build" ? "prod" : "prod"; // Default to "prod" bucket.
 
+  if (COMMIT_SHA_TRIMMED === UNKNOWN_SHA) {
+    // frapi looks lockfiles up by commit SHA, so anything filed under "unknown-sha" can never be
+    // promoted, and since only promoted lockfiles are ingested it will never reach the dashboard.
+    // Upload anyway so behavior does not change, but say so loudly.
+    console.error(
+      `WARNING: BUILD_GIT_CURRENT_SHA is not set for ${APP_NAME}. Uploading under "${UNKNOWN_SHA}", which frapi cannot promote, so this app's dependencies will not appear in the Frontier Dashboard.`
+    );
+  }
+
   console.log("Current Working Directory before CD: ", process.cwd());
   console.log("Changing directory to: ", APP_DIR);
 
@@ -53,7 +66,7 @@ try {
 
   if (!fs.existsSync("package-lock.json")) {
     console.log(
-      `Attempting to generate package-lock.json file for ${APP_NAME} in ${BUCKET_ENV}...`
+      `Attempting to generate package-lock.json file for ${APP_NAME}...`
     );
     shelljs.exec("npm install --package-lock-only");
 
@@ -67,54 +80,29 @@ try {
     `Uploading package-lock.json file to S3 in ${AWS.config.region} for ${APP_NAME} to frapi...`
   );
 
-  const devParams = {
-    Bucket: `${AWS_BUCKET_NAME}-dev`,
-    Key: `${APP_NAME}/${COMMIT_SHA_TRIMMED}-package-lock${packageLockGenerated ? '-generated' : ''}.json`,
-    Body: fs.createReadStream("package-lock.json"),
-  }
+  // One key shared by every bucket. These used to be three hand-maintained parameter objects, and
+  // the prod copy drifted onto a Date.now() timestamp -- which frapi could never match against a
+  // commit SHA, so no prod lockfile was ever promotable.
+  const key = `${APP_NAME}/${COMMIT_SHA_TRIMMED}-package-lock${packageLockGenerated ? '-generated' : ''}.json`;
 
-  const testParams = {
-    Bucket: `${AWS_BUCKET_NAME}-test`,
-    Key: `${APP_NAME}/${COMMIT_SHA_TRIMMED}-package-lock${packageLockGenerated ? '-generated' : ''}.json`,
-    Body: fs.createReadStream("package-lock.json"),
-  }
-
-  const prodParams = {
-    Bucket: `${AWS_BUCKET_NAME}-prod`,
-    Key: `${APP_NAME}/${Date.now()}-package-lock.json`,
-    Body: fs.createReadStream("package-lock.json"),
-  };
+  // Read once into a buffer rather than opening a stream per upload: a read stream can only be
+  // consumed once, so sharing one across the three uploads would silently truncate two of them.
+  const body = fs.readFileSync("package-lock.json");
 
   const s3 = new AWS.S3();
 
-  s3.upload(devParams, (err, data) => {
-    if (err) {
-      console.error("Error uploading dev package-lock.json file to S3");
-      console.error(err);
-    } else {
-      console.log("Successfully uploaded dev package-lock.json file to S3");
-      console.log(data);
-    }
-  });
+  BUCKET_ENVS.forEach((env) => {
+    const Bucket = `${AWS_BUCKET_NAME}-${env}`;
 
-  s3.upload(testParams, (err, data) => {
-    if (err) {
-      console.error("Error uploading test package-lock.json file to S3");
-      console.error(err);
-    } else {
-      console.log("Successfully uploaded test package-lock.json file to S3");
-      console.log(data);
-    }
-  });
-
-  s3.upload(prodParams, (err, data) => {
-    if (err) {
-      console.error("Error uploading prod package-lock.json file to S3");
-      console.error(err);
-    } else {
-      console.log("Successfully uploaded prod package-lock.json file to S3");
-      console.log(data);
-    }
+    s3.upload({ Bucket, Key: key, Body: body }, (err, data) => {
+      if (err) {
+        console.error(`Error uploading ${env} package-lock.json file to S3`);
+        console.error(err);
+      } else {
+        console.log(`Successfully uploaded ${env} package-lock.json file to S3 at ${Bucket}/${key}`);
+        console.log(data);
+      }
+    });
   });
 } catch (error) {
   console.error("Error uploading package-lock.json files to S3");

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "aws-sdk": "^2.5.0",
-        "lodash": "^4.15.0",
-        "mime-types": "^2.1.11",
         "shelljs": "^0.8.5"
       }
     },
@@ -318,30 +316,6 @@
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "engines": {
         "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -739,24 +713,6 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-    },
-    "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "requires": {
-        "mime-db": "1.52.0"
-      }
     },
     "minimatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
   "homepage": "https://github.com/Lostmyname/heroku-buildpack-upload-static-assets-to-s3#readme",
   "dependencies": {
     "aws-sdk": "^2.5.0",
-    "lodash": "^4.15.0",
-    "mime-types": "^2.1.11",
     "shelljs": "^0.8.5"
   },
   "directories": {


### PR DESCRIPTION
## Why

frapi's `PromoteDeployedDependencies` finds a build's lockfile by the first 20 characters of the deploy's commit SHA. Dev and test keys have always been written that way. The prod parameters used `Date.now()` instead, so **no prod lockfile has ever been promotable** — frapi looks for a SHA prefix and finds a timestamp.

This is the last thing blocking the Frontier Dashboard from reporting deployed versions in production. Part of FRONTIER-3955; the frapi side is fs-webdev/frapi#75.

## What changed

**Prod keys now match dev and test.** Rather than editing the prod string in place, the three hand-maintained parameter objects collapse into one shared `key`. That triplication is how prod drifted in the first place, so removing it prevents a repeat.

**Read once into a buffer instead of a stream per upload.** This is load-bearing, not tidying: a read stream can only be consumed once, so looping over a single shared stream would have silently truncated two of the three uploads. The original opened three separate streams, which was correct.

**Fixed a `ReferenceError` that suppressed uploads entirely.** The branch that generates a lockfile when the app hasn't committed one referenced `BUCKET_ENV`, whose declaration is commented out a few lines above. The outer catch turned that into `"Exiting upload task without error"`, so apps without a committed `package-lock.json` uploaded nothing at all.

**`BUILD_GIT_CURRENT_SHA` unset now warns.** The key becomes `unknown-sha-package-lock.json`, which frapi cannot promote and therefore never ingests — the app just quietly disappears from the dashboard. Upload still proceeds; only visibility changed.

**Dropped `lodash` and `mime-types`.** Neither is required anywhere in `lib/` or `bin/`; both are left over from the `heroku-buildpack-upload-static-assets-to-s3` fork. `lodash` also has a blocked tarball in Artifactory, which meant `npm install` couldn't complete in this repo at all.

## ⚠ This reaches every app on its next build the moment it merges

Apps consume this buildpack as an **unpinned git URL** in `.buildpacks` — confirmed in `pilot-dashboard`, `arc-record-exchange`, `discovery-kids`, `authorities-admin`, `get-involved`, `home-portal`, and `fs-labs`. `bin/compile` runs `npm install` and executes `lib/upload.js` from the checkout at build time. There is no staged rollout and no rollback other than another merge.

Blast radius if this is wrong: dependency reporting stops for the fleet. It cannot fail an app's build — every failure path ends in `process.exit(0)`.

## Testing

Verified with a stubbed S3 client (no network, no writes):

| Scenario | Result |
| --- | --- |
| Lockfile present, SHA set | All three buckets get the identical key `{app}/{sha20}-package-lock.json` |
| `BUILD_GIT_CURRENT_SHA` unset | Warning emitted; upload proceeds under `unknown-sha` |
| No `package-lock.json` | Generates one, uploads with the `-generated` suffix — previously threw `ReferenceError` and uploaded nothing |

A separate run against real S3 with deliberately invalid credentials returned `InvalidAccessKeyId` for all three buckets, confirming the path reaches S3 without writing.

## Deliberately not in scope

**The `aws-sdk` v2 → v3 migration.** v2 is end-of-support and FRONTIER-3705 calls for moving off it, but that's a larger change and this one is on the critical path. Left for a follow-up.

**Bucket routing.** The commented-out `TARGET_ENV → BUCKET_ENV` logic still isn't restored, so every build uploads to all three buckets and `frontier-packagelock-prod` keeps accumulating integration builds that will never be promoted. Restoring it changes which SHAs are promotable and could break promotion if it disagrees with where the provisioner invokes from — worth a deliberate decision rather than folding into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)